### PR TITLE
Tag-based releases, legacy rule cleanup, and dynamic POM versions

### DIFF
--- a/language/generate.go
+++ b/language/generate.go
@@ -137,6 +137,8 @@ func generateJavaBundleRules(config *MergedConfig, bundleName string, allProtoTa
 		"--artifact-id %s "+
 		"--version \"$${VERSION:-1.0.0}\" "+
 		"--repo \"$${MAVEN_REPO:-file://~/.m2/repository}\" "+
+		"--protobuf-version \"$${PROTOBUF_JAVA_VERSION:-4.33.5}\" "+
+		"--grpc-version \"$${GRPC_VERSION:-1.78.0}\" "+
 		"> $@",
 		bundleName, config.JavaConfig.GroupId, config.JavaConfig.ArtifactId)
 	publishMavenRule.SetAttr("cmd", publishCmd)


### PR DESCRIPTION
## Summary
- Switch release workflow from commit-pinned to tag-based `git_override` installation
- Clean up legacy `js_grpc_library`/`js_grpc_web_library` rules via `GenerateResult.Empty` during Gazelle merge (replaced by Connect-ES `es_proto_compile`)
- Forward `PROTOBUF_JAVA_VERSION` and `GRPC_VERSION` env vars to the `publish_to_maven` genrule so POM files reflect the lake's configured dependency versions

## Test plan
- [x] `bazel test //...` passes (unit tests updated for new kinds/loads)
- [x] E2E test (`test_protolake.sh`) passes with 73/73 assertions
- [x] Verified POM contains correct `4.33.5` protobuf version (not stale `3.25.3`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)