### PR TITLE
Use bundle.yaml version in publish genrule defaults

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -192,7 +192,7 @@ proto_library(
 display_name: "Common Types"
 description: "Common shared types"
 bundle_prefix: "com.testcompany"
-version: "1.0.0"
+version: "2.3.0"
 config:
   languages:
     java:
@@ -353,7 +353,8 @@ func verifyUserBundle(t *testing.T, content string) {
 	requireContains(t, content, "_all_protos", "aggregated proto rule")
 
 	// Hybrid approach: environment variables in publish genrules
-	requireContains(t, content, "${VERSION:-", "VERSION env var in publish cmd")
+	// Version default must come from bundle.yaml (1.0.0), not be hardcoded
+	requireContains(t, content, "${VERSION:-1.0.0}", "VERSION default from bundle.yaml (1.0.0)")
 	requireContains(t, content, "${MAVEN_REPO:-", "MAVEN_REPO env var in publish cmd")
 	requireContains(t, content, "publish_", "publish genrule")
 
@@ -387,6 +388,10 @@ func verifyCommonBundle(t *testing.T, content string) {
 	requireAbsent(t, content, "js_proto_bundle", "js_proto_bundle (JS disabled)")
 	requireAbsent(t, content, "es_proto_compile", "es_proto_compile (JS disabled)")
 	requireAbsent(t, content, "publish_common-types_to_npm", "npm publish (JS disabled)")
+
+	// Version default must come from bundle.yaml (2.3.0), not hardcoded 1.0.0
+	requireContains(t, content, "${VERSION:-2.3.0}", "VERSION default from bundle.yaml (2.3.0)")
+	requireAbsent(t, content, "${VERSION:-1.0.0}", "VERSION must not use 1.0.0 default (common-types is 2.3.0)")
 
 	// Publishing rules for maven and pypi only
 	requireContains(t, content, "publish_common-types_to_maven", "maven publish rule")

--- a/language/generate.go
+++ b/language/generate.go
@@ -135,12 +135,12 @@ func generateJavaBundleRules(config *MergedConfig, bundleName string, allProtoTa
 		"$(location :%s_java_bundle) "+
 		"--group-id %s "+
 		"--artifact-id %s "+
-		"--version \"$${VERSION:-1.0.0}\" "+
+		"--version \"$${VERSION:-%s}\" "+
 		"--repo \"$${MAVEN_REPO:-file://~/.m2/repository}\" "+
 		"--protobuf-version \"$${PROTOBUF_JAVA_VERSION:-4.33.5}\" "+
 		"--grpc-version \"$${GRPC_VERSION:-1.78.0}\" "+
 		"> $@",
-		bundleName, config.JavaConfig.GroupId, config.JavaConfig.ArtifactId)
+		bundleName, config.JavaConfig.GroupId, config.JavaConfig.ArtifactId, config.Version)
 	publishMavenRule.SetAttr("cmd", publishCmd)
 	publishMavenRule.SetAttr("tools", rule.PlatformStrings{Generic: []string{"//tools:publish_to_maven"}})
 	rules = append(rules, publishMavenRule)
@@ -185,10 +185,10 @@ func generatePythonBundleRules(config *MergedConfig, bundleName string, allProto
 	publishCmd := fmt.Sprintf("$(location //tools:publish_to_pypi) "+
 		"$(location :%s_py_bundle) "+
 		"--package-name %s "+
-		"--version \"$${VERSION:-1.0.0}\" "+
+		"--version \"$${VERSION:-%s}\" "+
 		"--repo \"$${PYPI_REPO:-file://~/.pypi}\" "+
 		"> $@",
-		bundleName, config.PythonConfig.PackageName)
+		bundleName, config.PythonConfig.PackageName, config.Version)
 	publishPypiRule.SetAttr("cmd", publishCmd)
 	publishPypiRule.SetAttr("tools", rule.PlatformStrings{Generic: []string{"//tools:publish_to_pypi"}})
 	rules = append(rules, publishPypiRule)
@@ -227,11 +227,11 @@ func generateJavaScriptBundleRules(config *MergedConfig, bundleName string, allP
 	publishNpmRule.SetAttr("srcs", rule.PlatformStrings{Generic: []string{fmt.Sprintf(":%s_js_bundle", bundleName)}})
 	publishNpmRule.SetAttr("outs", rule.PlatformStrings{Generic: []string{"publish_npm.log"}})
 	// Command with environment variable expansion
-	publishCmd := fmt.Sprintf("echo '%s@'\"$${VERSION:-1.0.0}\" > %s_coords.txt && "+
+	publishCmd := fmt.Sprintf("echo '%s@'\"$${VERSION:-%s}\" > %s_coords.txt && "+
 		"$(location //tools:publish_to_npm) "+
 		"$(location :%s_js_bundle) %s_coords.txt "+
 		"> $@",
-		config.JavaScriptConfig.PackageName, bundleName, bundleName, bundleName)
+		config.JavaScriptConfig.PackageName, config.Version, bundleName, bundleName, bundleName)
 	publishNpmRule.SetAttr("cmd", publishCmd)
 	publishNpmRule.SetAttr("tools", rule.PlatformStrings{Generic: []string{"//tools:publish_to_npm"}})
 	rules = append(rules, publishNpmRule)
@@ -274,11 +274,11 @@ func generateProtoLoaderBundleRules(config *MergedConfig, bundleName string, all
 	publishProtoLoaderRule := rule.NewRule("genrule", fmt.Sprintf("publish_%s_proto_loader_to_npm", bundleName))
 	publishProtoLoaderRule.SetAttr("srcs", rule.PlatformStrings{Generic: []string{fmt.Sprintf(":%s_proto_loader_bundle", bundleName)}})
 	publishProtoLoaderRule.SetAttr("outs", rule.PlatformStrings{Generic: []string{"publish_proto_loader_npm.log"}})
-	publishCmd := fmt.Sprintf("echo '%s@'\"$${VERSION:-1.0.0}\" > %s_proto_loader_coords.txt && "+
+	publishCmd := fmt.Sprintf("echo '%s@'\"$${VERSION:-%s}\" > %s_proto_loader_coords.txt && "+
 		"$(location //tools:publish_proto_loader_to_npm) "+
 		"$(location :%s_proto_loader_bundle) %s_proto_loader_coords.txt "+
 		"> $@",
-		loaderPkgName, bundleName, bundleName, bundleName)
+		loaderPkgName, config.Version, bundleName, bundleName, bundleName)
 	publishProtoLoaderRule.SetAttr("cmd", publishCmd)
 	publishProtoLoaderRule.SetAttr("tools", rule.PlatformStrings{Generic: []string{"//tools:publish_proto_loader_to_npm"}})
 	rules = append(rules, publishProtoLoaderRule)


### PR DESCRIPTION
## Summary

- Publish genrules now use `config.Version` from `bundle.yaml` instead of hardcoded `1.0.0` in all `${VERSION:-<version>}` expansions
- Maven, Python (PyPI), and npm publish genrules all read the bundle's configured version as the default
- `VERSION` env var still overrides at build time

Companion to protolake service commit [`efae7b4`](https://github.com/cohub-space/protolake/commit/efae7b4) which added dependency snippets, version management, and config resolution.

## Test plan

- [x] `bazel test //...` passes (unit + integration tests)
- [x] Integration test updated to expect bundle.yaml version in genrule commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)