### PR TITLE
feat: wire generate_descriptor_set into java_proto_bundle

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -99,6 +99,9 @@ def js_proto_bundle(name, proto_deps=[], es_deps=[], package_name="", **kwargs):
 
 def build_validation(name, targets=[], **kwargs):
     native.genrule(name = name, outs = [name + ".validation"], cmd = "echo 'Build validation passed' > $@", **kwargs)
+
+def proto_descriptor_set(name, deps=[], **kwargs):
+    native.filegroup(name = name, srcs = deps, visibility = kwargs.get("visibility", []))
 `)
 
 	writeFile(t, toolsDir, "es_proto.bzl", `def es_proto_compile(**kwargs):
@@ -123,6 +126,7 @@ description: "User service proto definitions"
 bundle_prefix: "com.testcompany"
 version: "1.0.0"
 config:
+  generate_descriptor_set: true
   languages:
     java:
       enabled: true
@@ -372,6 +376,13 @@ func verifyUserBundle(t *testing.T, content string) {
 	// Cross-bundle dependency: user.proto imports common.proto, so the
 	// generated gRPC rules should reference the common types target.
 	requireContains(t, content, "//com/testcompany/common/types/v1:", "cross-bundle proto target reference")
+
+	// Descriptor set is enabled for user-service: expect proto_descriptor_set rule
+	// and the java_proto_bundle wired to receive it via descriptor_pb/bundle_name.
+	requireContains(t, content, "proto_descriptor_set(", "proto_descriptor_set rule")
+	requireContains(t, content, `name = "user-service_descriptor"`, "descriptor target name")
+	requireContains(t, content, `descriptor_pb = ":user-service_descriptor"`, "java bundle wires descriptor_pb")
+	requireContains(t, content, `bundle_name = "user-service"`, "java bundle sets bundle_name")
 }
 
 // verifyCommonBundle checks the common-types bundle BUILD file.
@@ -402,6 +413,12 @@ func verifyCommonBundle(t *testing.T, content string) {
 	requireContains(t, content, "common-types_java_bundle", "java target in build_validation")
 	requireContains(t, content, "common-types_py_bundle", "python target in build_validation")
 	requireAbsent(t, content, "common-types_js_bundle", "js target in build_validation (JS disabled)")
+
+	// Descriptor set NOT enabled for common-types: rule must be absent and
+	// java_proto_bundle must not carry the descriptor attributes.
+	requireAbsent(t, content, "proto_descriptor_set(", "proto_descriptor_set rule (not requested)")
+	requireAbsent(t, content, "descriptor_pb =", "descriptor_pb attribute (not requested)")
+	requireAbsent(t, content, "bundle_name =", "bundle_name attribute (not requested)")
 }
 
 // verifySubdirectoryTargets checks that proto files in subdirectories

--- a/language/generate.go
+++ b/language/generate.go
@@ -123,6 +123,12 @@ func generateJavaBundleRules(config *MergedConfig, bundleName string, allProtoTa
 	if config.JavaConfig.FatJar {
 		javaBundleRule.SetAttr("fat_jar", true)
 	}
+	// When the bundle requests a proto descriptor, wire the descriptor target
+	// into the JAR so it ships at META-INF/proto-descriptors/<bundle>.pb.
+	if config.GenerateDescriptorSet {
+		javaBundleRule.SetAttr("descriptor_pb", fmt.Sprintf(":%s_descriptor", bundleName))
+		javaBundleRule.SetAttr("bundle_name", bundleName)
+	}
 	javaBundleRule.SetAttr("visibility", []string{"//visibility:public"})
 	rules = append(rules, javaBundleRule)
 


### PR DESCRIPTION
## Summary
- When a bundle opts in with `config.generate_descriptor_set: true` and has a Java bundle enabled, Gazelle now emits a `proto_descriptor_set(name="<bundle>_descriptor", ...)` rule AND wires `descriptor_pb = ":<bundle>_descriptor"` + `bundle_name = "<bundle>"` onto the `java_proto_bundle` rule.
- Downstream, the protolake JAR bundler packs the resulting `.pb` into `META-INF/proto-descriptors/<bundle>.pb` so consumers (Envoy gRPC-JSON transcoding, grpcurl, schema registries) can pull it from the published artifact instead of rebuilding it themselves.
- Integration test covers both the opt-in case (user-service bundle) and the opt-out case (common-types bundle).

## Why
AuthZaaS's local-dev Envoy was 404-ing every transcoded REST call because the authzaas `pom.xml` rebuilt the descriptor via `protobuf-maven-plugin outputDescriptorFile`, which silently produced an incomplete FileDescriptorSet. Shipping the descriptor from the one place that actually has all the protos (Bazel) fixes the root cause and standardizes the convention for future services.

## Related PRs
Part of the multi-repo PL-d5f3 change:
- `protolake` — adds `descriptor_pb`/`bundle_name` attrs to `java_proto_bundle` + new e2e test harness
- `cohub-protolake` — opts the authz bundle in; regenerates BUILD.bazel
- `authzaas` — stops rebuilding the descriptor in pom.xml; unpacks it from the proto JAR
- `cohub-knowledge` — design doc + knowledge doc updates + task file

Design: `cohub-knowledge/docs/designs/protolake/descriptor-sets-in-jars.md`

## Test plan
- [x] `integration_test.go` passes with new positive/negative assertions
- [ ] Run `protolake/e2e/test_protolake.sh` with this gazelle branch pointed at via `PROTOLAKE_GAZELLE_SOURCE_PATH` — asserts descriptor is present in service_a JAR, absent in service_b JAR

🤖 Generated with [Claude Code](https://claude.com/claude-code)