### PR TITLE
feat: wire external proto deps into Python + JS bundles

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -144,11 +144,15 @@ config:
 	writeFile(t, userDir, "BUILD.bazel", "")
 
 	// api/v1/user.proto — imports common.proto (cross-bundle dependency)
+	// plus google/api/annotations.proto (external dependency — exercises
+	// the multi-language external-deps wiring).
 	writeFile(t, userApiDir, "user.proto", `syntax = "proto3";
 
 package com.testcompany.user.api.v1;
 
 import "com/testcompany/common/types/v1/common.proto";
+import "google/api/annotations.proto";
+import "google/api/field_behavior.proto";
 
 service UserService {
   rpc GetUser(GetUserRequest) returns (GetUserResponse);
@@ -181,7 +185,11 @@ message CreateUserResponse {
 proto_library(
     name = "user_proto",
     srcs = ["user.proto"],
-    deps = ["//com/testcompany/common/types/v1:common_proto"],
+    deps = [
+        "//com/testcompany/common/types/v1:common_proto",
+        "@googleapis//google/api:annotations_proto",
+        "@googleapis//google/api:field_behavior_proto",
+    ],
     visibility = ["//visibility:public"],
 )
 `)
@@ -383,6 +391,21 @@ func verifyUserBundle(t *testing.T, content string) {
 	requireContains(t, content, `name = "user-service_descriptor"`, "descriptor target name")
 	requireContains(t, content, `descriptor_pb = ":user-service_descriptor"`, "java bundle wires descriptor_pb")
 	requireContains(t, content, `bundle_name = "user-service"`, "java bundle sets bundle_name")
+
+	// External deps: user.proto imports google/api/annotations.proto, so:
+	//   - java_grpc_library.deps must include the Java umbrella library
+	//   - python_grpc_library.protos must include the raw proto_library targets
+	//   - es_proto_compile.protos must include the raw proto_library targets
+	requireContains(t, content, `"@googleapis//google/api:api_java_proto"`,
+		"java_grpc_library deps include googleapis java umbrella")
+	requireContains(t, content, `"@googleapis//google/api:annotations_proto"`,
+		"python_grpc_library + es_proto_compile protos include annotations_proto")
+	requireContains(t, content, `"@googleapis//google/api:field_behavior_proto"`,
+		"protos include field_behavior_proto")
+	requireContains(t, content, `"@googleapis//google/api:http_proto"`,
+		"protos include http_proto (transitive companion)")
+	requireContains(t, content, `"@googleapis//google/api:launch_stage_proto"`,
+		"protos include launch_stage_proto (pulled in by client.proto)")
 }
 
 // verifyCommonBundle checks the common-types bundle BUILD file.
@@ -419,6 +442,10 @@ func verifyCommonBundle(t *testing.T, content string) {
 	requireAbsent(t, content, "proto_descriptor_set(", "proto_descriptor_set rule (not requested)")
 	requireAbsent(t, content, "descriptor_pb =", "descriptor_pb attribute (not requested)")
 	requireAbsent(t, content, "bundle_name =", "bundle_name attribute (not requested)")
+
+	// common-types doesn't import google/api, so no external deps should appear.
+	requireAbsent(t, content, "@googleapis//", "googleapis deps (not imported)")
+	requireAbsent(t, content, "api_java_proto", "Java umbrella dep (not imported)")
 }
 
 // verifySubdirectoryTargets checks that proto files in subdirectories

--- a/language/generate.go
+++ b/language/generate.go
@@ -35,14 +35,17 @@ func generateBundleRules(config *MergedConfig, protoTargets []string, rel string
 	log.Printf("Bundle %s has %d direct proto targets and %d total with transitive deps",
 		bundleName, len(protoTargets), len(allProtoTargets))
 
-	// Detect external proto imports to determine additional Java dependencies
-	externalJavaDeps := detectExternalJavaDeps(bundleDir)
+	// Detect external proto imports and derive per-language Bazel targets. Java
+	// depends on a pre-compiled umbrella library (googleapis-java); Python and JS
+	// have no such umbrella today, so they compile the external proto_library
+	// targets directly alongside the bundle's own protos.
+	externalDeps := detectExternalProtoImports(bundleDir)
 
 	// Generate Java bundle if enabled
 	log.Printf("Checking Java bundle generation - Enabled: %v, GroupId: '%s', ArtifactId: '%s'",
 		config.JavaConfig.Enabled, config.JavaConfig.GroupId, config.JavaConfig.ArtifactId)
 	if config.JavaConfig.Enabled && config.JavaConfig.GroupId != "" && config.JavaConfig.ArtifactId != "" {
-		rules = append(rules, generateJavaBundleRules(config, bundleName, allProtoTargets, externalJavaDeps)...)
+		rules = append(rules, generateJavaBundleRules(config, bundleName, allProtoTargets, externalDeps.Java)...)
 	} else {
 		log.Printf("Skipping Java bundle generation for %s", bundleName)
 	}
@@ -51,7 +54,7 @@ func generateBundleRules(config *MergedConfig, protoTargets []string, rel string
 	log.Printf("Checking Python bundle generation - Enabled: %v, PackageName: '%s'",
 		config.PythonConfig.Enabled, config.PythonConfig.PackageName)
 	if config.PythonConfig.Enabled && config.PythonConfig.PackageName != "" {
-		rules = append(rules, generatePythonBundleRules(config, bundleName, allProtoTargets)...)
+		rules = append(rules, generatePythonBundleRules(config, bundleName, allProtoTargets, externalDeps.ProtoLibraries)...)
 	} else {
 		log.Printf("Skipping Python bundle generation for %s", bundleName)
 	}
@@ -60,7 +63,7 @@ func generateBundleRules(config *MergedConfig, protoTargets []string, rel string
 	log.Printf("Checking JavaScript bundle generation - Enabled: %v, PackageName: '%s'",
 		config.JavaScriptConfig.Enabled, config.JavaScriptConfig.PackageName)
 	if config.JavaScriptConfig.Enabled && config.JavaScriptConfig.PackageName != "" {
-		rules = append(rules, generateJavaScriptBundleRules(config, bundleName, allProtoTargets)...)
+		rules = append(rules, generateJavaScriptBundleRules(config, bundleName, allProtoTargets, externalDeps.ProtoLibraries)...)
 	} else {
 		log.Printf("Skipping JavaScript bundle generation for %s", bundleName)
 	}
@@ -161,13 +164,23 @@ func generateJavaBundleRules(config *MergedConfig, bundleName string, allProtoTa
 }
 
 // generatePythonBundleRules creates Python bundle rules with hybrid publishing
-func generatePythonBundleRules(config *MergedConfig, bundleName string, allProtoTargets []string) []*rule.Rule {
+func generatePythonBundleRules(config *MergedConfig, bundleName string, allProtoTargets []string, externalProtoLibraries []string) []*rule.Rule {
 	var rules []*rule.Rule
 
-	// Python gRPC library (includes both proto messages and gRPC stubs)
+	// Python gRPC library (includes both proto messages and gRPC stubs).
+	// External proto_library targets (e.g. @googleapis//google/api:annotations_proto)
+	// are appended to `protos` so rules_proto_grpc_python compiles them alongside
+	// the bundle's own protos — without this the published wheel would be missing
+	// google/api/*_pb2.py companions.
 	pythonGrpcRule := rule.NewRule("python_grpc_library", fmt.Sprintf("%s_python_grpc", bundleName))
-	pythonGrpcRule.SetAttr("protos", rule.PlatformStrings{Generic: allProtoTargets})
+	protos := append([]string{}, allProtoTargets...)
+	protos = append(protos, externalProtoLibraries...)
+	pythonGrpcRule.SetAttr("protos", rule.PlatformStrings{Generic: protos})
 	pythonGrpcRule.SetAttr("visibility", []string{"//visibility:public"})
+	if len(externalProtoLibraries) > 0 {
+		log.Printf("Added %d external proto_library targets to %s_python_grpc: %v",
+			len(externalProtoLibraries), bundleName, externalProtoLibraries)
+	}
 	rules = append(rules, pythonGrpcRule)
 
 	// Python bundle rule with STATIC configuration (no version attribute)
@@ -209,13 +222,23 @@ func generatePythonBundleRules(config *MergedConfig, bundleName string, allProto
 }
 
 // generateJavaScriptBundleRules creates JavaScript bundle rules with Connect-ES and hybrid publishing
-func generateJavaScriptBundleRules(config *MergedConfig, bundleName string, allProtoTargets []string) []*rule.Rule {
+func generateJavaScriptBundleRules(config *MergedConfig, bundleName string, allProtoTargets []string, externalProtoLibraries []string) []*rule.Rule {
 	var rules []*rule.Rule
 
-	// Connect-ES compilation (protoc-gen-es) — generates _pb.js + _pb.d.ts
+	// Connect-ES compilation (protoc-gen-es) — generates _pb.js + _pb.d.ts.
+	// External proto_library targets (e.g. @googleapis//google/api:annotations_proto)
+	// are appended to `protos` so protoc-gen-es produces _pb.js for them too —
+	// without this the generated authz_pb.js would reference missing
+	// ../../../google/api/*_pb imports and the consumer's build would fail.
 	esProtoRule := rule.NewRule("es_proto_compile", fmt.Sprintf("%s_es_proto", bundleName))
-	esProtoRule.SetAttr("protos", rule.PlatformStrings{Generic: allProtoTargets})
+	protos := append([]string{}, allProtoTargets...)
+	protos = append(protos, externalProtoLibraries...)
+	esProtoRule.SetAttr("protos", rule.PlatformStrings{Generic: protos})
 	esProtoRule.SetAttr("visibility", []string{"//visibility:public"})
+	if len(externalProtoLibraries) > 0 {
+		log.Printf("Added %d external proto_library targets to %s_es_proto: %v",
+			len(externalProtoLibraries), bundleName, externalProtoLibraries)
+	}
 	rules = append(rules, esProtoRule)
 
 	// JavaScript bundle rule with Connect-ES deps
@@ -314,9 +337,42 @@ func generateLegacyCleanupRules(config *MergedConfig) []*rule.Rule {
 	return empty
 }
 
-// detectExternalJavaDeps scans proto files in a bundle directory and returns
-// Bazel Java library targets needed for external proto imports (googleapis, protovalidate).
-func detectExternalJavaDeps(bundleDir string) []string {
+// ExternalProtoDeps carries the Bazel targets that need to be wired into per-language
+// rules when a bundle's protos import external sources (googleapis, protovalidate).
+//
+//   - Java uses pre-compiled umbrella library targets (e.g. api_java_proto) — these are
+//     passed to `java_grpc_library.deps` so the JAR depends on already-built classes.
+//   - Python and JS have no umbrella equivalent in this workspace, so the raw
+//     proto_library targets are compiled alongside the bundle's own protos by
+//     appending them to the `protos` attribute of `python_grpc_library` and
+//     `es_proto_compile`. This produces the matching _pb2.py / _pb.js companions
+//     inside the published wheel / npm tarball.
+type ExternalProtoDeps struct {
+	// Java target list (umbrella libraries, typically one entry per provider).
+	Java []string
+	// Raw proto_library targets, used by Python and JS which recompile per-bundle.
+	ProtoLibraries []string
+}
+
+// googleapisJsProtos is the set of google/api protos our consumers transitively need
+// when any google/api/*.proto is imported. protoc compiles only the srcs of each
+// listed proto_library (not their transitive imports), so we include the whole set
+// rather than trying to resolve each import graph precisely. launch_stage is
+// pulled in by client.proto; the remaining ones cover the annotations we see
+// across cohub bundles today. This is a small set and the extra _pb.js files
+// are negligible in the published tarball.
+var googleapisJsProtos = []string{
+	"@googleapis//google/api:annotations_proto",
+	"@googleapis//google/api:client_proto",
+	"@googleapis//google/api:field_behavior_proto",
+	"@googleapis//google/api:http_proto",
+	"@googleapis//google/api:launch_stage_proto",
+	"@googleapis//google/api:resource_proto",
+}
+
+// detectExternalProtoImports scans a bundle's .proto files and returns the per-language
+// Bazel targets required to satisfy external imports (googleapis, protovalidate).
+func detectExternalProtoImports(bundleDir string) ExternalProtoDeps {
 	needsGoogleapis := false
 	needsProtovalidate := false
 
@@ -338,14 +394,18 @@ func detectExternalJavaDeps(bundleDir string) []string {
 		}
 	}
 
-	var deps []string
+	var out ExternalProtoDeps
 	if needsGoogleapis {
-		deps = append(deps, "@googleapis//google/api:api_java_proto")
+		out.Java = append(out.Java, "@googleapis//google/api:api_java_proto")
+		out.ProtoLibraries = append(out.ProtoLibraries, googleapisJsProtos...)
 	}
 	if needsProtovalidate {
-		deps = append(deps, "//:protovalidate_java_proto")
+		out.Java = append(out.Java, "//:protovalidate_java_proto")
+		// Raw proto_library lives under the module's proto/ subtree — see the lake's
+		// `protovalidate_java_proto` target for the canonical path.
+		out.ProtoLibraries = append(out.ProtoLibraries, "@protovalidate//proto/protovalidate/buf/validate:validate_proto")
 	}
-	return deps
+	return out
 }
 
 // collectBundleTransitiveDependencies finds transitive dependencies for a specific bundle

--- a/language/protolake.go
+++ b/language/protolake.go
@@ -297,6 +297,38 @@ func (pe *protolakeExtension) KindInfo() map[string]rule.KindInfo {
 			NonEmptyAttrs: map[string]bool{
 				"protos": true,
 			},
+			// MergeableAttrs lets Gazelle overwrite these attributes on existing rules
+			// during a regenerate pass. Without this, changes to external proto deps
+			// (added by detectExternalProtoImports for google/api, buf/validate, etc.)
+			// would not propagate into checked-in BUILD.bazel files.
+			MergeableAttrs: map[string]bool{
+				"protos":     true,
+				"visibility": true,
+			},
+		},
+		// java_grpc_library + python_grpc_library live in @rules_proto_grpc_{java,python}
+		// but we generate them from this extension and want to merge our attrs into
+		// existing checked-in rules. Register KindInfo so Gazelle knows to merge
+		// `protos` and `deps` (external proto deps added by detectExternalProtoImports).
+		"java_grpc_library": {
+			NonEmptyAttrs: map[string]bool{
+				"protos": true,
+			},
+			MergeableAttrs: map[string]bool{
+				"protos":     true,
+				"deps":       true,
+				"visibility": true,
+			},
+		},
+		"python_grpc_library": {
+			NonEmptyAttrs: map[string]bool{
+				"protos": true,
+			},
+			MergeableAttrs: map[string]bool{
+				"protos":     true,
+				"deps":       true,
+				"visibility": true,
+			},
 		},
 		"proto_descriptor_set": {
 			NonEmptyAttrs: map[string]bool{


### PR DESCRIPTION
## Summary
Generalise `detectExternalJavaDeps` → `detectExternalProtoImports` so protolake-gazelle wires external proto dependencies into **all three** language rules, not just Java. Register `KindInfo` with `MergeableAttrs` for `java_grpc_library`, `python_grpc_library`, and `es_proto_compile` so updates merge into checked-in BUILD files on regeneration.

## Why
Java has long received external proto deps via a pre-compiled umbrella library (`@googleapis//google/api:api_java_proto`). Python and JS had no equivalent — the respective `python_grpc_library` and `es_proto_compile` rules only received the bundle's own protos. Published wheels and npm tarballs therefore shipped without `google/api/*_pb2.py` / `*_pb.js` companions.

Discovered while building the AuthZaaS UI: `@cohub/authz-proto` shipped `.proto` sources under `external/googleapis+/google/api/` but no compiled JS, so every `*_pb.js` had dangling imports like `../../../google/api/annotations_pb` and the consumer build failed.

## Per-language model
| Language | Wiring |
|---|---|
| Java | `java_grpc_library.deps = ["@googleapis//google/api:api_java_proto"]` — pre-compiled umbrella |
| Python | `python_grpc_library.protos = [bundle_proto, "@googleapis//google/api:annotations_proto", ...]` — raw proto_library targets; rules_proto_grpc_python compiles each |
| JavaScript | `es_proto_compile.protos = [bundle_proto, "@googleapis//google/api:annotations_proto", ...]` — same pattern; protoc-gen-es emits _pb.js for each |

Detection is a single proto-import scan; the mapping table is small (google/api, buf/validate) and hardcoded in `generate.go:googleapisJsProtos`. For google/api we include the full transitive set (`annotations`, `client`, `field_behavior`, `http`, `launch_stage`, `resource`) since `protoc` doesn't cascade into imports.

## Why the `MergeableAttrs` change matters
Without explicit `MergeableAttrs`, Gazelle's default merge behaviour preserves existing attributes on checked-in rules and only adds missing ones. The first time a consumer ran Gazelle it would stamp in the new deps, but subsequent regenerations (after `bundle.yaml` edits, new protos, etc.) would leave them stale. Adding `MergeableAttrs: {"protos": true, "deps": true}` for these kinds lets Gazelle overwrite on every run.

## Test plan
- [x] `bazel test //:integration_test` — `user.proto` imports `google/api/{annotations,field_behavior}`; assertions verify java `deps`, python `protos`, and ES `protos` all pick up the googleapis targets. Negative assertion on `common-types` (no external imports) stays green.
- [x] End-to-end: regenerated `cohub-protolake/cohub/authz/BUILD.bazel` via `protolakew build --js-target <ui>`; `@cohub/authz-proto` now ships `cohub/authz/authz_es_proto/google/api/*_pb.js`; authzaas-ui `npm run build` succeeds with no dangling imports.
- [x] `protovalidate` path verified against the lake's existing `//:protovalidate_java_proto` wrapper (target is `@protovalidate//proto/protovalidate/buf/validate:validate_proto`).

## Related
- Companion PR on `cohub-protolake` regenerates BUILD.bazel for the fix
- Docs update in `cohub-knowledge` (`protolake-gazelle.md`, `protolake-connectrpc.md`, task `PL-g4c7`)
- Discovered from AuthZaaS UI work (branch `feat/AZ-2ae7-ui-p1` on authzaas), which now consumes `@cohub/authz-proto` directly via `protolakew --js-target` instead of a local buf codegen workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)