### PR TITLE
feat: wire google/longrunning external deps in gazelle

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -144,8 +144,8 @@ config:
 	writeFile(t, userDir, "BUILD.bazel", "")
 
 	// api/v1/user.proto — imports common.proto (cross-bundle dependency)
-	// plus google/api/annotations.proto (external dependency — exercises
-	// the multi-language external-deps wiring).
+	// plus google/api/annotations.proto and google/longrunning/operations.proto
+	// (external dependencies — exercises the multi-language external-deps wiring).
 	writeFile(t, userApiDir, "user.proto", `syntax = "proto3";
 
 package com.testcompany.user.api.v1;
@@ -153,10 +153,12 @@ package com.testcompany.user.api.v1;
 import "com/testcompany/common/types/v1/common.proto";
 import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
+import "google/longrunning/operations.proto";
 
 service UserService {
   rpc GetUser(GetUserRequest) returns (GetUserResponse);
   rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+  rpc CreateUserAsync(CreateUserRequest) returns (google.longrunning.Operation);
 }
 
 message GetUserRequest {
@@ -189,6 +191,7 @@ proto_library(
         "//com/testcompany/common/types/v1:common_proto",
         "@googleapis//google/api:annotations_proto",
         "@googleapis//google/api:field_behavior_proto",
+        "@googleapis//google/longrunning:operations_proto",
     ],
     visibility = ["//visibility:public"],
 )
@@ -392,8 +395,9 @@ func verifyUserBundle(t *testing.T, content string) {
 	requireContains(t, content, `descriptor_pb = ":user-service_descriptor"`, "java bundle wires descriptor_pb")
 	requireContains(t, content, `bundle_name = "user-service"`, "java bundle sets bundle_name")
 
-	// External deps: user.proto imports google/api/annotations.proto, so:
-	//   - java_grpc_library.deps must include the Java umbrella library
+	// External deps: user.proto imports google/api/annotations.proto and
+	// google/longrunning/operations.proto, so:
+	//   - java_grpc_library.deps must include the Java umbrella libraries
 	//   - python_grpc_library.protos must include the raw proto_library targets
 	//   - es_proto_compile.protos must include the raw proto_library targets
 	requireContains(t, content, `"@googleapis//google/api:api_java_proto"`,
@@ -406,6 +410,10 @@ func verifyUserBundle(t *testing.T, content string) {
 		"protos include http_proto (transitive companion)")
 	requireContains(t, content, `"@googleapis//google/api:launch_stage_proto"`,
 		"protos include launch_stage_proto (pulled in by client.proto)")
+	requireContains(t, content, `"@googleapis//google/longrunning:longrunning_java_proto"`,
+		"java_grpc_library deps include longrunning java umbrella")
+	requireContains(t, content, `"@googleapis//google/longrunning:operations_proto"`,
+		"python_grpc_library + es_proto_compile protos include longrunning operations_proto")
 }
 
 // verifyCommonBundle checks the common-types bundle BUILD file.

--- a/language/generate.go
+++ b/language/generate.go
@@ -371,9 +371,11 @@ var googleapisJsProtos = []string{
 }
 
 // detectExternalProtoImports scans a bundle's .proto files and returns the per-language
-// Bazel targets required to satisfy external imports (googleapis, protovalidate).
+// Bazel targets required to satisfy external imports (googleapis, longrunning,
+// protovalidate).
 func detectExternalProtoImports(bundleDir string) ExternalProtoDeps {
 	needsGoogleapis := false
+	needsLongrunning := false
 	needsProtovalidate := false
 
 	protoFiles := collectBundleProtoFiles(bundleDir)
@@ -388,6 +390,9 @@ func detectExternalProtoImports(bundleDir string) ExternalProtoDeps {
 			if strings.HasPrefix(importPath, "google/api/") {
 				needsGoogleapis = true
 			}
+			if strings.HasPrefix(importPath, "google/longrunning/") {
+				needsLongrunning = true
+			}
 			if strings.HasPrefix(importPath, "buf/validate/") {
 				needsProtovalidate = true
 			}
@@ -398,6 +403,13 @@ func detectExternalProtoImports(bundleDir string) ExternalProtoDeps {
 	if needsGoogleapis {
 		out.Java = append(out.Java, "@googleapis//google/api:api_java_proto")
 		out.ProtoLibraries = append(out.ProtoLibraries, googleapisJsProtos...)
+	}
+	if needsLongrunning {
+		// Java umbrella target aggregates longrunning message + gRPC classes.
+		out.Java = append(out.Java, "@googleapis//google/longrunning:longrunning_java_proto")
+		// Python/JS recompile raw proto_library targets per-bundle — operations.proto
+		// is the only file under google/longrunning and carries everything callers need.
+		out.ProtoLibraries = append(out.ProtoLibraries, "@googleapis//google/longrunning:operations_proto")
 	}
 	if needsProtovalidate {
 		out.Java = append(out.Java, "//:protovalidate_java_proto")


### PR DESCRIPTION
## Summary
- Extend `detectExternalProtoImports` to recognize `google/longrunning/*` imports.
- Java: `@googleapis//google/longrunning:longrunning_java_proto` (umbrella).
- Python/JS: `@googleapis//google/longrunning:operations_proto` (raw proto_library).
- Mirrors the existing `google/api/*` handling.

## Why
`cohub-protolake` needs a new `cohub/vdp` bundle for the VDP proto migration (VDP-7312). `operation_service.proto` uses `google.longrunning.Operation` as the return type of long-running RPCs (`ValidateBoard`, `GenerateBoard`, etc.). Without this wiring, gazelle generates BUILD files that fail to resolve longrunning's Bazel targets, blocking the bundle build.

## Test plan
- [x] `go test ./language/...` passes.
- [x] `go vet ./...` clean.
- [x] `bazel test //:integration_test` passes. Integration test's user-service bundle now imports `google/longrunning/operations.proto` and the BUILD assertions verify both the Java umbrella and Python/JS raw proto_library targets appear.
- [ ] Downstream: `cohub-protolake` builds the `cohub/vdp` bundle green against this tag.

## Related
- Task: VDP-7312-migrate-vdp-protos
- Follows: PL-g4c7 (which generalized `detectExternalJavaDeps` → `detectExternalProtoImports` for Python/JS).