### PR TITLE
docs: rewrite README for current rule emission + publish model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,34 @@
 # protolake-gazelle
 
-A Gazelle extension for Proto Lake that automatically generates Bazel BUILD files for protocol buffer service bundles.
+A [Bazel Gazelle](https://github.com/bazelbuild/bazel-gazelle) language
+extension that generates BUILD files for proto bundles in
+[Proto Lake](https://github.com/cohub-space/protolake) workspaces.
 
-## Overview
+For most users, you don't install this directly — Proto Lake bundles it
+into the lake's `MODULE.bazel`. This README is for: standalone use
+(running gazelle without protolake), local development of the extension
+itself, and reference for the rules it emits.
 
-protolake-gazelle extends [Bazel Gazelle](https://github.com/bazelbuild/bazel-gazelle) to understand Proto Lake's bundle structure and automatically generate BUILD files with multi-language support (Java, Python, JavaScript/TypeScript).
+For deep architecture (configuration loading, transitive dependency
+collection, version handling) see the
+[cohub-knowledge protolake-gazelle doc](https://github.com/cohub-space/cohub-knowledge/blob/main/docs/knowledge/protolake/protolake-gazelle.md).
 
-## Features
+## What it generates
 
-- **Automatic Bundle Detection**: Finds directories containing `bundle.yaml` files
-- **Multi-Language Support**: Generates rules for Java, Python, and JavaScript/TypeScript
-- **Configuration Inheritance**: Bundle settings inherit from lake-wide defaults
-- **gRPC Support**: Automatically generates gRPC libraries when services are detected
-- **Hybrid Publishing**: Supports both static configuration and runtime parameters
+For each directory containing a `bundle.yaml`, the extension emits the
+full set of bundle rules: an aggregated `proto_library`, per-language
+gRPC + bundle rules, and per-language publish targets. Coordinates and
+versions are baked into the rules at gazelle time from the bundle's
+configuration.
 
-## Installation
-
-### Using as a Bazel Module
-
-In your `MODULE.bazel`:
-
-```starlark
-bazel_dep(name = "protolake_gazelle", version = "0.0.1")
-
-git_override(
-    module_name = "protolake_gazelle",
-    remote = "https://github.com/cohub-space/protolake-gazelle.git",
-    commit = "COMMIT_SHA", # Use a specific commit
-)
-```
-
-### Using with Proto Lake
-
-Proto Lake automatically includes this extension when creating new lakes. No manual installation needed!
-
-## Usage
-
-### Basic Usage
-
-Create a `bundle.yaml` in your proto directory:
+For a `bundle.yaml` like:
 
 ```yaml
-bundle:
-  name: "user-service"
-  owner: "platform-team"
-  proto_package: "com.example.user"
-  description: "User service proto definitions"
-  version: "1.0.0"
+name: user-service
+display_name: User Service
+description: User service proto definitions
+bundle_prefix: com.example
+version: "1.0.0"
 config:
   languages:
     java:
@@ -61,140 +43,177 @@ config:
       package_name: "@example/user-service-proto"
 ```
 
-Run Gazelle:
-
-```bash
-bazel run //:gazelle
-```
-
-### Generated BUILD File
-
-The extension will generate a BUILD file with:
+the extension emits (abbreviated):
 
 ```starlark
-# Auto-generated proto aggregation
-proto_library(
-    name = "user_service_all_protos",
-    srcs = glob(["**/*.proto"]),
-    visibility = ["//visibility:public"],
-)
+load("@rules_jvm_external//private/rules:maven_publish.bzl", "maven_publish")
+load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_proto_grpc_java//:defs.bzl", "java_grpc_library")
+load("@rules_proto_grpc_python//:defs.bzl", "python_grpc_library")
+load("//tools:proto_bundle.bzl", "java_proto_bundle", "py_proto_bundle", "js_proto_bundle")
+load("//tools:es_proto.bzl", "es_proto_compile")
 
-# Java bundle
-java_proto_library(
-    name = "user_service_java_proto",
-    deps = [":user_service_all_protos"],
-)
+# Aggregated proto target — direct + recursive subdirectories
+proto_library(name = "user-service_all_protos", deps = [...])
 
+# Java path: bundle JAR + POM + maven_publish
+java_grpc_library(name = "user-service_java_grpc", protos = [...])
 java_proto_bundle(
-    name = "user_service_java_bundle",
-    proto_deps = [":user_service_all_protos"],
-    java_deps = [":user_service_java_proto"],
+    name = "user-service_java_bundle",
     group_id = "com.example.proto",
     artifact_id = "user-service-proto",
+    version = "1.0.0",
+    proto_deps = [":user-service_all_protos"],
+    java_deps = [":user-service_java_grpc"],
+    java_grpc_deps = [":user-service_java_grpc"],
+)
+genrule(
+    name = "user-service_pom",
+    outs = ["user-service.pom.xml"],
+    cmd = "$(location //tools:pom_generator) --group-id ... --version 1.0.0 ... --out $@",
+    tools = ["//tools:pom_generator"],
+)
+maven_publish(
+    name = "publish_user-service_to_maven",
+    coordinates = "com.example.proto:user-service-proto:1.0.0",
+    pom = ":user-service_pom",
+    artifact = ":user-service_java_bundle",
 )
 
-# Python bundle  
-py_proto_library(
-    name = "user_service_py_proto",
-    deps = [":user_service_all_protos"],
-)
-
+# Python path: wheel + py_binary publish
+python_grpc_library(name = "user-service_python_grpc", protos = [...])
 py_proto_bundle(
-    name = "user_service_py_bundle",
-    proto_deps = [":user_service_all_protos"],
-    py_deps = [":user_service_py_proto"],
+    name = "user-service_py_bundle",
     package_name = "example_user_proto",
+    version = "1.0.0",
+    proto_deps = [":user-service_all_protos"],
+    py_grpc_deps = [":user-service_python_grpc"],
+)
+py_binary(
+    name = "publish_user-service_to_pypi",
+    srcs = ["//tools:publish/pypi_publisher_generated.py"],
+    main = "publish/pypi_publisher_generated.py",
+    args = [
+        "$(location :user-service_py_bundle)",
+        "--package-name=example_user_proto",
+        "--version=1.0.0",
+    ],
+    data = [":user-service_py_bundle"],
+    deps = ["//tools:publisher_utils"],
 )
 
-# JavaScript bundle
-js_proto_library(
-    name = "user_service_js_proto",
-    deps = [":user_service_all_protos"],
-)
-
+# JS / TS path: tarball + py_binary publish (Connect-ES v2 codegen)
+es_proto_compile(name = "user-service_es_proto", protos = [...])
 js_proto_bundle(
-    name = "user_service_js_bundle",
-    proto_deps = [":user_service_all_protos"],
-    js_deps = [":user_service_js_proto"],
+    name = "user-service_js_bundle",
     package_name = "@example/user-service-proto",
+    version = "1.0.0",
+    proto_deps = [":user-service_all_protos"],
+    es_deps = [":user-service_es_proto"],
+)
+py_binary(name = "publish_user-service_to_npm", ...)  # similar to pypi
+```
+
+The publish targets are executable rules invoked via `bazel run` — see
+[publisher-execution-model.md](https://github.com/cohub-space/cohub-knowledge/blob/main/docs/designs/protolake/publisher-execution-model.md)
+for the rationale (bazel-native side-effecting model, fail-fast,
+tag-driven release flow via release-please).
+
+## Installation
+
+### Via Proto Lake (typical)
+
+If you're using a Proto Lake workspace, the extension is wired in
+automatically by `protolakew init` — `MODULE.bazel` and `BUILD.bazel`
+are generated for you. No manual setup needed.
+
+### Standalone
+
+In your `MODULE.bazel`:
+
+```starlark
+bazel_dep(name = "protolake_gazelle", version = "0.0.1")
+git_override(
+    module_name = "protolake_gazelle",
+    remote = "https://github.com/cohub-space/protolake-gazelle.git",
+    tag = "v0.3.0",   # or `commit = "<sha>"` for exact pinning
 )
 ```
+
+Then add a `lake.yaml` at the workspace root, a `bundle.yaml` in each
+proto directory, and run `bazel run //:gazelle`. The extension also
+expects supporting tools (`//tools:pom_generator`, `//tools:publish/*`,
+`//tools:proto_bundle.bzl`, etc.) — these are provided by Proto Lake
+templates. Standalone use without Proto Lake is possible but you'll
+need to set up the tools yourself.
 
 ## Configuration
 
-### Lake-Level Configuration
+The extension reads `lake.yaml` (walked up from the bundle directory)
+and `bundle.yaml` (the current directory). Bundle config overrides
+lake defaults via tri-state pointer semantics — `*bool` fields
+distinguish *unset* (inherit) from *explicitly false* (disable).
 
-Create a `lake.yaml` at the root of your Proto Lake:
+**`lake.yaml`** at the lake root:
 
 ```yaml
 config:
   language_defaults:
     java:
       enabled: true
-      group_id: "com.company.proto"
-      source_version: "11"
-      target_version: "8"
+      group_id: "com.example.proto"
     python:
       enabled: true
-      package_name: "company_proto"
-      python_version: ">=3.8"
+      package_prefix: "example_proto"
     javascript:
       enabled: true
-      package_name: "@company/proto"
+      package_scope: "@example"
 ```
 
-### Bundle-Level Configuration
-
-Bundle configuration in `bundle.yaml` overrides lake defaults:
+**`bundle.yaml`** in each bundle directory (overrides lake defaults):
 
 ```yaml
-bundle:
-  name: "special-service"
-  owner: "special-team"
+name: special-service
+version: "1.0.0"
 config:
   languages:
     java:
-      enabled: true
-      group_id: "com.special.proto" # Overrides lake default
+      group_id: "com.special.proto"   # overrides lake default
       artifact_id: "special-proto"
+    javascript:
+      enabled: false                  # explicitly disabled
 ```
 
-## Directives
-
-Control the extension behavior with Gazelle directives:
+## Gazelle directives
 
 ```starlark
-# Disable protolake extension for this directory
+# In a BUILD.bazel: disable protolake-gazelle for this directory only
 # gazelle:protolake false
 ```
 
 ## Development
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
-
-### Building
-
 ```bash
-bazel build //...
+bazel build //...        # build the extension + integration test fixtures
+bazel test //...         # run unit + integration tests
+go test ./language/...   # run Go unit tests directly (faster than bazel)
 ```
 
-### Testing
+The integration test (`//:integration_test`) generates BUILD files for
+a fixture two-bundle workspace and asserts the contents — fastest
+signal for rule-emission changes.
 
-```bash
-bazel test //...
-```
+When iterating on the extension while testing against a real lake, set
+`PROTOLAKE_GAZELLE_SOURCE_PATH` on `protolakew` and Proto Lake will use
+your local checkout instead of the published tag. See
+[dev-workflow.md](https://github.com/cohub-space/cohub-knowledge/blob/main/docs/knowledge/protolake/dev-workflow.md).
 
 ## License
 
-Apache License 2.0 - See [LICENSE](LICENSE) file for details.
+Apache License 2.0 — see [LICENSE](LICENSE).
 
-## Support
+## Related projects
 
-For issues and questions:
-- Open an issue on [GitHub](https://github.com/cohub-space/protolake-gazelle/issues)
-- Check existing issues for solutions
-
-## Related Projects
-
-- [Proto Lake](https://github.com/Cohub-Space/Protolake) - The main Proto Lake service
-- [Bazel Gazelle](https://github.com/bazelbuild/bazel-gazelle) - The extensible BUILD file generator
+- [Proto Lake](https://github.com/cohub-space/protolake) — the main service that consumes this extension
+- [Bazel Gazelle](https://github.com/bazelbuild/bazel-gazelle) — the underlying BUILD file generator


### PR DESCRIPTION
## Summary

The previous README had two consequential errors that misled users:

- **"Generated BUILD File" example** showed `java_proto_library`, `py_proto_library`, `js_proto_library` — **none of which the extension emits**. Actual output is `java_grpc_library` + `java_proto_bundle` + `_pom` genrule + `maven_publish` (and equivalents for py/js with `py_binary` for the publish targets).
- **"Hybrid Publishing"** feature claim — runtime parameters were removed in cohub-space/protolake#8 + cohub-space/protolake-gazelle#14. Coordinates and version are now baked at gazelle time from `bundle.yaml`; no runtime `${VERSION}` env var.

Other corrections:
- `bundle.yaml` example used the legacy nested `bundle:` schema; current schema is flat.
- `git_override` example used `commit = "COMMIT_SHA"` placeholder → switched to `tag = "v0.3.0"` (current Proto Lake default).

Restructured:
- Lead with **"What it generates"** — the actual output, with a complete example showing `maven_publish` + `py_binary` + bundle rules.
- **Installation** splits "Via Proto Lake (typical)" from "Standalone".
- Deeper material (transitive dep collection, configuration loading, version handling) lives in cohub-knowledge protolake-gazelle.md; this README cross-links there.

## Why now

Once cohub-space/protolake-gazelle#14 (which lands the new rule emission) merges, this README's BUILD-file example would actively mislead anyone reading. Better to land the README rewrite alongside the rule changes.

## Test plan

- [x] All cohub-knowledge cross-links resolve to live URLs on `main`
- [x] Generated BUILD example matches what `language/generate.go` emits today
- [ ] Visual rendering check on GitHub once the PR is open

## Related PRs

- protolake-gazelle: #14 (rule emission migration)
- protolake: #8 (server-side migration), #9 (READ​ME refresh)
- cohub-knowledge: #84 (knowledge / design doc updates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)