### PR TITLE
fix: propagate bundle.yaml version on regenerate; fail-fast when missing

### DIFF
--- a/language/generate.go
+++ b/language/generate.go
@@ -22,6 +22,17 @@ func generateBundleRules(config *MergedConfig, protoTargets []string, rel string
 	var rules []*rule.Rule
 	bundleName := config.BundleName
 
+	// Fail fast if version is missing. Defaulting to "1.0.0" silently masked the
+	// "bundle.yaml bumped but publish stuck at 1.0.0" failure mode for months —
+	// see PL-c4d8 / cohub-protolake#30 incident notes. Better to break the build
+	// loudly so the missing version is fixed at its source.
+	if config.Version == "" {
+		log.Fatalf("[protolake-gazelle] bundle %q at %s is missing required field "+
+			"`version` in bundle.yaml. Set an explicit version (e.g. `version: \"1.0.0\"`); "+
+			"omitting it would publish under a fallback that drifts silently.",
+			bundleName, rel)
+	}
+
 	// Create aggregated proto_library rule (for reference and compatibility)
 	allProtosRule := rule.NewRule("proto_library", fmt.Sprintf("%s_all_protos", bundleName))
 	allProtosRule.SetAttr("deps", rule.PlatformStrings{Generic: protoTargets})
@@ -118,13 +129,9 @@ func generateJavaBundleRules(config *MergedConfig, bundleName string, allProtoTa
 	javaGrpcRule.SetAttr("visibility", []string{"//visibility:public"})
 	rules = append(rules, javaGrpcRule)
 
-	// Version literal baked from bundle.yaml. Empty defaults to "1.0.0" so a
-	// bundle that forgets to set version still produces a valid coordinate
-	// (preserves the previous fallback behavior).
+	// Version literal baked from bundle.yaml. generateBundleRules already
+	// fail-fasts if config.Version is empty, so no fallback needed here.
 	version := config.Version
-	if version == "" {
-		version = "1.0.0"
-	}
 
 	// Java bundle rule. Coordinates come from configuration; the JAR's
 	// MANIFEST.MF carries the version (from `bundle.yaml`). The maven coordinate
@@ -210,10 +217,8 @@ func generatePythonBundleRules(config *MergedConfig, bundleName string, allProto
 	}
 	rules = append(rules, pythonGrpcRule)
 
+	// generateBundleRules already fail-fasts if config.Version is empty.
 	version := config.Version
-	if version == "" {
-		version = "1.0.0"
-	}
 
 	// Python bundle rule. Package name and version come from configuration —
 	// version is passed to wheel_builder via a rule attr, baked at gazelle time.
@@ -275,10 +280,8 @@ func generateJavaScriptBundleRules(config *MergedConfig, bundleName string, allP
 	}
 	rules = append(rules, esProtoRule)
 
+	// generateBundleRules already fail-fasts if config.Version is empty.
 	version := config.Version
-	if version == "" {
-		version = "1.0.0"
-	}
 
 	// JavaScript bundle rule with Connect-ES deps. Version baked at gazelle time.
 	jsBundleRule := rule.NewRule("js_proto_bundle", fmt.Sprintf("%s_js_bundle", bundleName))
@@ -330,10 +333,8 @@ func generateDescriptorSetRules(config *MergedConfig, bundleName string, protoTa
 func generateProtoLoaderBundleRules(config *MergedConfig, bundleName string, allProtoTargets []string) []*rule.Rule {
 	var rules []*rule.Rule
 
+	// generateBundleRules already fail-fasts if config.Version is empty.
 	version := config.Version
-	if version == "" {
-		version = "1.0.0"
-	}
 
 	// Proto-loader bundle rule
 	protoLoaderRule := rule.NewRule("js_proto_loader_bundle", fmt.Sprintf("%s_proto_loader_bundle", bundleName))

--- a/language/protolake.go
+++ b/language/protolake.go
@@ -277,6 +277,12 @@ func (pe *protolakeExtension) KindInfo() map[string]rule.KindInfo {
 				"java_deps":      true,
 				"java_grpc_deps": true,
 			},
+			// `version` must be mergeable so bundle.yaml version bumps
+			// propagate into the existing rule on regenerate. Without this,
+			// jar_bundler keeps stamping the previous version into MANIFEST.MF.
+			MergeableAttrs: map[string]bool{
+				"version": true,
+			},
 		},
 		"py_proto_bundle": {
 			NonEmptyAttrs: map[string]bool{
@@ -399,9 +405,16 @@ func (pe *protolakeExtension) KindInfo() map[string]rule.KindInfo {
 		// `genrule` is a built-in, but we declare it here so the merger can
 		// identify and delete the legacy `publish_<bundle>_to_*` genrules
 		// (replaced by maven_publish + py_binary in the publisher-execution-model
-		// migration).
+		// migration). `cmd` must be mergeable so version-bearing pom-generator
+		// invocations (e.g. `--version 1.0.0`) get rewritten when bundle.yaml
+		// bumps; without this the published POM XML carries the stale version
+		// while the JAR coordinate is fresh.
 		"genrule": {
 			NonEmptyAttrs: map[string]bool{
+				"cmd":  true,
+				"outs": true,
+			},
+			MergeableAttrs: map[string]bool{
 				"cmd":  true,
 				"outs": true,
 			},


### PR DESCRIPTION
## Summary

Two bugs in the version-bake-at-gazelle-time flow surfaced by cohub-space/cohub-protolake's first release-please cut.

## Bug 1 — version didn't propagate to existing rules

\`KindInfo\` for \`java_proto_bundle\` and \`genrule\` had no \`MergeableAttrs\` entry for \`version\` / \`cmd\`. So when bundle.yaml bumped from 1.0.0 → 1.1.1, gazelle re-generated rules with the new value but the merger left existing checked-in BUILD.bazel rules untouched.

Concrete failure ([actions/runs/25342668099](https://github.com/cohub-space/cohub-protolake/actions/runs/25342668099/job/74303736398)): cohub-protolake's first release cut bumped cohub-iam-proto to 1.1.1 in bundle.yaml, the publish workflow ran \`protolakew publish --bundle cohub/iam\`, gazelle ran but didn't update \`maven_publish.coordinates\`, the publish uploaded \`cohub-iam-proto:1.0.0\` (already in AR) and failed with \`generic::already_exists\`.

**Fix**: add \`version\` to \`java_proto_bundle.MergeableAttrs\` and \`cmd\`/\`outs\` to \`genrule.MergeableAttrs\`. (\`maven_publish.coordinates\`, \`py_binary.args\`, and the py/js bundle rules' \`version\` were already in MergeableAttrs on main, but only became effective once they all merge consistently.)

### Validated end-to-end against cohub-protolake

```
$ # bundle.yaml: version: "1.0.0", BUILD.bazel: version = "1.0.0" everywhere
$ sed -i 's/version: "1.0.0"/version: "1.5.0"/' cohub/iam/bundle.yaml
$ PROTOLAKE_GAZELLE_SOURCE_PATH=. ./protolakew --pull never publish --bundle cohub/iam
...
Successfully published to local PyPI repository:
  Package: cohub_iam_proto
  Version: 1.5.0

$ grep -E "version|coordinates" cohub/iam/BUILD.bazel
    version = "1.5.0",        ← java_proto_bundle
    version = "1.5.0",        ← py_proto_bundle
    version = "1.5.0",        ← js_proto_bundle
    cmd = "$(location //tools:pom_generator) ... --version 1.5.0 ...",
    coordinates = "space.cohub:cohub-iam-proto:1.5.0",
        "--version=1.5.0",    ← py_binary publish_to_npm args
        "--version=1.5.0",    ← py_binary publish_to_pypi args
```

## Bug 2 — empty version silently defaulted to "1.0.0"

The four per-language generators each had:

\`\`\`go
version := config.Version
if version == "" {
    version = "1.0.0"
}
\`\`\`

…exactly the silent-fallback that [PL-c4d8's task description](https://github.com/cohub-space/cohub-knowledge/blob/main/docs/tasks/PL-c4d8-publisher-execution-model.md) called out as the original "publish stuck at 1.0.0" trap, just one layer up.

**Fix**: fail-fast in \`generateBundleRules\` with a clear error pointing at the bundle and the missing field. The four per-language fallbacks are removed.

\`\`\`
gazelle: [protolake-gazelle] bundle "iam" at cohub/iam is missing required field
\`version\` in bundle.yaml. Set an explicit version (e.g. \`version: "1.0.0"\`);
omitting it would publish under a fallback that drifts silently.
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./language/...\` passes (integration test needs bazel runtime)
- [x] End-to-end: bundle.yaml bump → BUILD.bazel updates → publish at new version (validated against cohub-protolake)
- [x] End-to-end: bundle.yaml without version → gazelle exits with clear error
- [ ] Cut new tag (v0.4.0) after merge
- [ ] Bump protolake's default \`PROTOLAKE_GAZELLE_GIT_TAG\` to v0.4.0 in a follow-up PR

## Related

- Failing CI run: cohub-space/cohub-protolake [actions/runs/25342668099](https://github.com/cohub-space/cohub-protolake/actions/runs/25342668099/job/74303736398)
- Sibling fix that scoped the publish target query: cohub-space/protolake#15
- PL-c4d8 task: cohub-knowledge \`docs/tasks/PL-c4d8-publisher-execution-model.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)