### PR TITLE
chore: commit .claude cohub-knowledge wiring (backfill)

### DIFF
--- a/.claude/commands/capture.md
+++ b/.claude/commands/capture.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/capture.md

--- a/.claude/commands/close.md
+++ b/.claude/commands/close.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/close.md

--- a/.claude/commands/closeout.md
+++ b/.claude/commands/closeout.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/closeout.md

--- a/.claude/commands/comments.md
+++ b/.claude/commands/comments.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/comments.md

--- a/.claude/commands/create.md
+++ b/.claude/commands/create.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/create.md

--- a/.claude/commands/fire.md
+++ b/.claude/commands/fire.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/fire.md

--- a/.claude/commands/handoff.md
+++ b/.claude/commands/handoff.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/handoff.md

--- a/.claude/commands/kickoff.md
+++ b/.claude/commands/kickoff.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/kickoff.md

--- a/.claude/commands/next.md
+++ b/.claude/commands/next.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/next.md

--- a/.claude/commands/quick.md
+++ b/.claude/commands/quick.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/quick.md

--- a/.claude/commands/rebuild.md
+++ b/.claude/commands/rebuild.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/rebuild.md

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/status.md

--- a/.claude/commands/stop.md
+++ b/.claude/commands/stop.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/stop.md

--- a/.claude/commands/sync.md
+++ b/.claude/commands/sync.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/sync.md

--- a/.claude/commands/tasks.md
+++ b/.claude/commands/tasks.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/tasks.md

--- a/.claude/commands/wip.md
+++ b/.claude/commands/wip.md
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/commands/wip.md

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "env": {
+    "CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD": "1"
+  }
+}

--- a/.claude/skills/address-pr-comments
+++ b/.claude/skills/address-pr-comments
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/skills/address-pr-comments

--- a/.claude/skills/claude-code-dev
+++ b/.claude/skills/claude-code-dev
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/skills/claude-code-dev

--- a/.claude/skills/feature-design
+++ b/.claude/skills/feature-design
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/skills/feature-design

--- a/.claude/skills/knowledge-update
+++ b/.claude/skills/knowledge-update
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/skills/knowledge-update

--- a/.claude/skills/quick
+++ b/.claude/skills/quick
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/skills/quick

--- a/.claude/skills/research
+++ b/.claude/skills/research
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/skills/research

--- a/.claude/skills/service-docs-update
+++ b/.claude/skills/service-docs-update
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/skills/service-docs-update

--- a/.claude/skills/session-handoff
+++ b/.claude/skills/session-handoff
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/skills/session-handoff

--- a/.claude/skills/sync-workspace
+++ b/.claude/skills/sync-workspace
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/skills/sync-workspace

--- a/.claude/skills/task-management
+++ b/.claude/skills/task-management
@@ -1,0 +1,1 @@
+../../../../cohub-knowledge/.claude/skills/task-management


### PR DESCRIPTION
Backfill from G-f9a0: commits the cohub-knowledge wiring that `setup-repo.py` creates — `.claude/settings.json` plus per-item skill/command symlinks — so a fresh clone + `setup.py` leaves this repo's tree clean. `.claude/settings.local.json` stays gitignored (per-developer).

## Related PRs
- cohub-knowledge: cohub-space/cohub-knowledge#289 (setup.py --verify + HTTPS clone URLs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9WR5c2nnpsxDxDMajTLSN