### PR TITLE
feat: emit a -local publish twin per Java bundle

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -375,6 +375,11 @@ func verifyUserBundle(t *testing.T, content string) {
 	requireContains(t, content, "publish_user-service_to_maven", "maven publish target")
 	requireContains(t, content, "publish_user-service_to_pypi", "pypi publish target")
 	requireContains(t, content, "publish_user-service_to_npm", "npm publish target")
+	// Local-publish twin: -local qualifier keeps local installs off the
+	// release coordinates.
+	requireContains(t, content, "publish_user-service_to_maven_local", "maven local publish target")
+	requireContains(t, content, `coordinates = "com.testcompany.proto:user-service-proto:1.0.0-local"`,
+		"local Maven coordinates carry the -local qualifier")
 	requireAbsent(t, content, "${VERSION:", "no runtime VERSION env-var dance after gazelle bake")
 
 	// build_validation with all 3 language bundle targets
@@ -443,6 +448,8 @@ func verifyCommonBundle(t *testing.T, content string) {
 	requireContains(t, content, `--version=2.3.0`, "Version baked into py_binary args")
 	requireContains(t, content, "publish_common-types_to_maven", "maven publish target")
 	requireContains(t, content, "publish_common-types_to_pypi", "pypi publish target")
+	requireContains(t, content, `coordinates = "com.testcompany.proto:common-types-proto:2.3.0-local"`,
+		"local Maven coordinates carry the -local qualifier")
 
 	// Regression check for the version-stuck-at-1.0.0 bug: common-types is 2.3.0
 	// and must never appear with the 1.0.0 fallback.

--- a/language/generate.go
+++ b/language/generate.go
@@ -189,6 +189,38 @@ func generateJavaBundleRules(config *MergedConfig, bundleName string, allProtoTa
 	publishMavenAlias.SetAttr("visibility", []string{"//visibility:public"})
 	rules = append(rules, publishMavenAlias)
 
+	// Local-publish twin at a `-local`-qualified version. Maven caches a
+	// release version forever, so a local install at the release coordinates
+	// silently shadows the eventual CI release on that machine. Keeping local
+	// installs at `<version>-local` leaves the release name vacant; consumers
+	// under test pin the qualifier explicitly. The orchestrator runs this
+	// target instead of the plain one when MAVEN_REPO is not an http(s)
+	// registry (protolake BazelBuildRunner).
+	localVersion := version + "-local"
+	pomLocalRule := rule.NewRule("genrule", fmt.Sprintf("%s_pom_local", bundleName))
+	pomLocalRule.SetAttr("outs", rule.PlatformStrings{Generic: []string{fmt.Sprintf("%s.pom_local.xml", bundleName)}})
+	pomLocalCmd := fmt.Sprintf(
+		"$(location //tools:pom_generator) "+
+			"--group-id %s "+
+			"--artifact-id %s "+
+			"--version %s "+
+			"--protobuf-version $${PROTOBUF_JAVA_VERSION:-4.33.5} "+
+			"--grpc-version $${GRPC_VERSION:-1.78.0} "+
+			"--out $@",
+		config.JavaConfig.GroupId, config.JavaConfig.ArtifactId, localVersion)
+	pomLocalRule.SetAttr("cmd", pomLocalCmd)
+	pomLocalRule.SetAttr("tools", rule.PlatformStrings{Generic: []string{"//tools:pom_generator"}})
+	pomLocalRule.SetAttr("visibility", []string{"//visibility:public"})
+	rules = append(rules, pomLocalRule)
+
+	publishMavenLocalRule := rule.NewRule("maven_publish", fmt.Sprintf("publish_%s_to_maven_local", bundleName))
+	publishMavenLocalRule.SetAttr("coordinates",
+		fmt.Sprintf("%s:%s:%s", config.JavaConfig.GroupId, config.JavaConfig.ArtifactId, localVersion))
+	publishMavenLocalRule.SetAttr("pom", fmt.Sprintf(":%s_pom_local", bundleName))
+	publishMavenLocalRule.SetAttr("artifact", fmt.Sprintf(":%s_java_bundle", bundleName))
+	publishMavenLocalRule.SetAttr("visibility", []string{"//visibility:public"})
+	rules = append(rules, publishMavenLocalRule)
+
 	return rules
 }
 


### PR DESCRIPTION
## What
Per Java bundle, gazelle now emits a second, fully static publish pair: `publish_<name>_to_maven_local` + `<name>_pom_local`, at `<version>-local` coordinates. No run-time defines or stamping — both targets are hermetic at analysis time.

## Why
Maven never re-checks a release version it already has: a local install at the release coordinates (`protolakew publish` with the default local repo) permanently shadows the eventual CI release on that machine. This bit hard in G-sdef — a mid-development local `2.12.0` kept resurrecting pre-#105 validation rules days after the real 2.12.0 shipped. With the twin, local installs land at `2.12.0-local`, the release name stays vacant, and consumers under test pin the qualifier explicitly (a visible, revertable diff).

## Consumer half
protolake's BazelBuildRunner picks the `_local` target when MAVEN_REPO is not an http(s) registry — see the paired protolake PR. Old lakes without the twin fall back to the plain target with a warning.

## Verification
`go test ./language/...` green; integration assertions added for both fixture bundles (need the bazel-built binary — CI).

## Related PRs
- protolake: feat/local-publish-qualifier (target selection by mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)