### PR TITLE
fix: self-referential _all_protos on regen; gofmt sweep + idempotency pin

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -36,13 +36,23 @@ func TestGazelleIntegration(t *testing.T) {
 
 	// Fixed-point idempotency: a second gazelle pass over the same tree must
 	// change NOTHING — every BUILD file byte-identical, the legacy MIGRATION
-	// fixture included. Migrating an OLD-form BUILD used to be a two-pass
-	// convergence (the seeded `_all_protos` block appeared to relocate on
-	// pass 2): the discovery regex was re-matching the bundle's own generated
-	// `_all_protos` aggregate and wiring it into its own deps — a
-	// self-referential proto_library. Since discoverExistingProtoTargets skips
-	// the bundle's own aggregate, every bundle — fresh, cleaned, or migrated —
-	// reaches its fixed point on the first pass; this pins that.
+	// fixture included.
+	//
+	// History, for the record. Pre-fix, a protolake-pass-only regen over an
+	// already-generated tree re-discovered the bundle's own `_all_protos`
+	// aggregate and injected it into its own deps — a bazel dependency-cycle
+	// error if built. Fresh/cleaned bundles (user, common) corrupted on pass 2,
+	// which this byte-stability check catches; the legacy fixture, whose seeded
+	// BUILD already carried the aggregate, corrupted on pass 1 and was
+	// byte-STABLE in the corrupted state — that shape is guarded by the
+	// self-reference check in verifyLegacyMigration, not by stability alone.
+	// The lake service's real flow (a gazelle proto-language pass that deletes
+	// the srcs-less aggregate, then the protolake pass) masked the injection by
+	// removing the aggregate before discovery; that wrapper flow can still show
+	// a benign one-time aggregate relocation on its first run over a
+	// pre-steady-state tree. Post-fix (discovery skips the aggregate in the
+	// bundle dir only), the protolake pass in isolation — what this test runs —
+	// is single-pass byte-stable for every bundle shape.
 	pass1 := captureBuildFiles(t, testDir)
 	runGazelle(t, testDir)
 	pass2 := captureBuildFiles(t, testDir)
@@ -291,6 +301,32 @@ proto_library(
         "@googleapis//google/api:field_behavior_proto",
         "@googleapis//google/longrunning:operations_proto",
     ],
+    visibility = ["//visibility:public"],
+)
+`)
+
+	// extra/ holds a user-defined proto_library that deliberately shares the
+	// bundle's aggregate rule name. The aggregate skip in proto-target
+	// discovery must apply only to the bundle directory itself — this
+	// subdirectory target is a legitimate source target and silently dropping
+	// it would strip its protos from every published artifact.
+	userExtraDir := filepath.Join(userDir, "extra")
+	os.MkdirAll(userExtraDir, 0755)
+
+	writeFile(t, userExtraDir, "extra.proto", `syntax = "proto3";
+
+package com.testcompany.user.extra;
+
+message Extra {
+  string note = 1;
+}
+`)
+
+	writeFile(t, userExtraDir, "BUILD.bazel", `load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "user-service_all_protos",
+    srcs = ["extra.proto"],
     visibility = ["//visibility:public"],
 )
 `)
@@ -776,6 +812,13 @@ func verifyUserBundle(t *testing.T, content string) {
 	// Cross-bundle dependency: user.proto imports common.proto, so the
 	// generated gRPC rules should reference the common types target.
 	requireContains(t, content, "//com/testcompany/common/types/v1:", "cross-bundle proto target reference")
+
+	// A user-defined proto_library that shares the aggregate's rule name but
+	// lives in a SUBDIRECTORY is a legitimate source target: the aggregate
+	// skip applies only to the bundle directory itself, so this target must
+	// be discovered and wired into the bundle rules.
+	requireContains(t, content, `"//com/testcompany/user/extra:user-service_all_protos"`,
+		"same-named subdirectory proto_library discovered and wired in")
 
 	// Descriptor set is enabled for user-service: expect proto_descriptor_set rule
 	// and the java_proto_bundle wired to receive it via descriptor_pb/bundle_name.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -31,6 +32,22 @@ func TestGazelleIntegration(t *testing.T) {
 	t.Run("LegacyMigration", func(t *testing.T) { verifyLegacyMigration(t, legacyContent) })
 	t.Run("SubdirectoryTargets", func(t *testing.T) {
 		verifySubdirectoryTargets(t, userContent, commonContent)
+	})
+
+	// Fixed-point idempotency: a second gazelle pass over the same tree must
+	// change NOTHING — every BUILD file byte-identical, the legacy MIGRATION
+	// fixture included. Migrating an OLD-form BUILD used to be a two-pass
+	// convergence (the seeded `_all_protos` block appeared to relocate on
+	// pass 2): the discovery regex was re-matching the bundle's own generated
+	// `_all_protos` aggregate and wiring it into its own deps — a
+	// self-referential proto_library. Since discoverExistingProtoTargets skips
+	// the bundle's own aggregate, every bundle — fresh, cleaned, or migrated —
+	// reaches its fixed point on the first pass; this pins that.
+	pass1 := captureBuildFiles(t, testDir)
+	runGazelle(t, testDir)
+	pass2 := captureBuildFiles(t, testDir)
+	t.Run("SecondPassIdempotency", func(t *testing.T) {
+		requireBuildFilesIdentical(t, pass1, pass2)
 	})
 }
 
@@ -890,6 +907,12 @@ func verifyLegacyMigration(t *testing.T, content string) {
 
 	// Nothing anywhere in the migrated file may still reference the stale version.
 	requireAbsent(t, content, "9.9.9", "stale version literal fully gone")
+
+	// The seeded `_all_protos` aggregate must not be re-discovered as a proto
+	// target of its own bundle: that wired the aggregate into its own deps (a
+	// self-referential proto_library) and into the grpc/es rules' protos.
+	requireAbsent(t, content, "//com/testcompany/legacy:legacy-service_all_protos",
+		"bundle's own aggregate self-referenced as a proto target")
 }
 
 // verifySubdirectoryTargets checks that proto files in subdirectories
@@ -905,6 +928,58 @@ func verifySubdirectoryTargets(t *testing.T, userContent, commonContent string) 
 // ---------------------------------------------------------------------------
 // Test helpers
 // ---------------------------------------------------------------------------
+
+const buildBazelName = "BUILD.bazel"
+
+// captureBuildFiles walks root and returns every BUILD.bazel's contents,
+// keyed by slash-separated path relative to root.
+func captureBuildFiles(t *testing.T, root string) map[string]string {
+	t.Helper()
+	files := make(map[string]string)
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() || d.Name() != buildBazelName {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files[filepath.ToSlash(rel)] = string(content)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to capture BUILD files under %s: %v", root, err)
+	}
+	return files
+}
+
+// requireBuildFilesIdentical asserts that before and after hold the same
+// BUILD file set with byte-identical contents.
+func requireBuildFilesIdentical(t *testing.T, before, after map[string]string) {
+	t.Helper()
+	for rel, prev := range before {
+		cur, ok := after[rel]
+		if !ok {
+			t.Errorf("BUILD file disappeared between passes: %s", rel)
+			continue
+		}
+		if cur != prev {
+			t.Errorf("BUILD file not byte-identical between passes: %s\n--- earlier pass ---\n%s\n--- later pass ---\n%s", rel, prev, cur)
+		}
+	}
+	for rel := range after {
+		if _, ok := before[rel]; !ok {
+			t.Errorf("BUILD file appeared between passes: %s", rel)
+		}
+	}
+}
 
 func requireContains(t *testing.T, content, pattern, description string) {
 	t.Helper()

--- a/language/bundle.go
+++ b/language/bundle.go
@@ -220,15 +220,15 @@ func MergeConfigurations(lakeConfig *LakeConfig, bundleConfig *BundleConfig) *Me
 
 // MergedConfig represents the final configuration after merging lake and bundle configs
 type MergedConfig struct {
-	BundleName           string
-	BundleOwner          string
-	ProtoPackage         string
-	Description          string
-	Version              string
+	BundleName            string
+	BundleOwner           string
+	ProtoPackage          string
+	Description           string
+	Version               string
 	GenerateDescriptorSet bool
-	JavaConfig           JavaConfig
-	PythonConfig         PythonConfig
-	JavaScriptConfig     JavaScriptConfig
+	JavaConfig            JavaConfig
+	PythonConfig          PythonConfig
+	JavaScriptConfig      JavaScriptConfig
 }
 
 type JavaConfig struct {

--- a/language/protolake.go
+++ b/language/protolake.go
@@ -182,9 +182,12 @@ func (pe *protolakeExtension) GenerateRules(args language.GenerateArgs) language
 
 // discoverExistingProtoTargets finds proto_library targets in the current directory and subdirectories
 // This enhanced version searches recursively to support bundles with protos in subdirectories.
-// The bundle's own aggregated rule (<bundle>_all_protos) is excluded: it is an output of this
-// extension, regenerated every pass — discovering it as a source target would wire the aggregate
-// into its own deps (a self-referential proto_library) on any run over an already-generated tree.
+// The bundle's own aggregated rule (<bundle>_all_protos) is excluded from the bundle-dir scan:
+// it is an output of this extension, regenerated every pass — discovering it as a source target
+// would wire the aggregate into its own deps (a self-referential proto_library) on any run over
+// an already-generated tree. The skip applies ONLY to the bundle's own directory: a user-defined
+// proto_library in a subdirectory that happens to share the aggregate's name is a legitimate
+// source target and must still be discovered.
 func (pe *protolakeExtension) discoverExistingProtoTargets(args language.GenerateArgs, bundleName string) []string {
 	var targets []string
 	aggregateRuleName := bundleName + "_all_protos"
@@ -193,7 +196,7 @@ func (pe *protolakeExtension) discoverExistingProtoTargets(args language.Generat
 	targets = append(targets, pe.discoverProtoTargetsInDirectory(args.Dir, args.Config.RepoRoot, aggregateRuleName)...)
 
 	// Then recursively search subdirectories for additional proto targets
-	subdirTargets := pe.discoverProtoTargetsRecursively(args.Dir, args.Config.RepoRoot, aggregateRuleName)
+	subdirTargets := pe.discoverProtoTargetsRecursively(args.Dir, args.Config.RepoRoot)
 	targets = append(targets, subdirTargets...)
 
 	log.Printf("Discovered %d total proto targets for bundle: %v", len(targets), targets)
@@ -201,7 +204,8 @@ func (pe *protolakeExtension) discoverExistingProtoTargets(args language.Generat
 }
 
 // discoverProtoTargetsInDirectory finds proto_library targets in a specific directory,
-// skipping any rule named skipRuleName (the bundle's own generated aggregate).
+// skipping any rule named skipRuleName. Callers pass the bundle's generated aggregate
+// name when scanning the bundle's own directory and "" (no skip) everywhere else.
 func (pe *protolakeExtension) discoverProtoTargetsInDirectory(dir string, repoRoot string, skipRuleName string) []string {
 	var targets []string
 
@@ -232,7 +236,7 @@ func (pe *protolakeExtension) discoverProtoTargetsInDirectory(dir string, repoRo
 		if len(match) > 1 {
 			name := match[1]
 
-			if name == skipRuleName {
+			if skipRuleName != "" && name == skipRuleName {
 				continue
 			}
 
@@ -254,9 +258,11 @@ func (pe *protolakeExtension) discoverProtoTargetsInDirectory(dir string, repoRo
 	return targets
 }
 
-// discoverProtoTargetsRecursively finds proto_library targets in all subdirectories,
-// skipping any rule named skipRuleName (the bundle's own generated aggregate).
-func (pe *protolakeExtension) discoverProtoTargetsRecursively(bundleDir string, repoRoot string, skipRuleName string) []string {
+// discoverProtoTargetsRecursively finds proto_library targets in all subdirectories.
+// BUILD files sitting in bundleDir itself are excluded — the caller already scanned
+// that directory (with the bundle's generated aggregate skipped); rescanning it here
+// would duplicate its targets and re-discover the aggregate without the skip.
+func (pe *protolakeExtension) discoverProtoTargetsRecursively(bundleDir string, repoRoot string) []string {
 	var targets []string
 
 	// Walk through all subdirectories
@@ -275,10 +281,13 @@ func (pe *protolakeExtension) discoverProtoTargetsRecursively(bundleDir string, 
 			return filepath.SkipDir
 		}
 
-		// Process BUILD files
+		// Process BUILD files in subdirectories only
 		if info.Name() == buildBazelFile || info.Name() == buildFile {
 			dir := filepath.Dir(path)
-			dirTargets := pe.discoverProtoTargetsInDirectory(dir, repoRoot, skipRuleName)
+			if dir == bundleDir {
+				return nil
+			}
+			dirTargets := pe.discoverProtoTargetsInDirectory(dir, repoRoot, "")
 			targets = append(targets, dirTargets...)
 		}
 

--- a/language/protolake.go
+++ b/language/protolake.go
@@ -143,7 +143,7 @@ func (pe *protolakeExtension) GenerateRules(args language.GenerateArgs) language
 	log.Printf("Processing bundle: %s at %s", mergedConfig.BundleName, args.Rel)
 
 	// Discover existing proto targets from BUILD files (including subdirectories)
-	protoTargets := pe.discoverExistingProtoTargets(args)
+	protoTargets := pe.discoverExistingProtoTargets(args, mergedConfig.BundleName)
 	if len(protoTargets) == 0 {
 		log.Printf("No proto targets found for bundle %s", mergedConfig.BundleName)
 		return language.GenerateResult{}
@@ -181,23 +181,28 @@ func (pe *protolakeExtension) GenerateRules(args language.GenerateArgs) language
 }
 
 // discoverExistingProtoTargets finds proto_library targets in the current directory and subdirectories
-// This enhanced version searches recursively to support bundles with protos in subdirectories
-func (pe *protolakeExtension) discoverExistingProtoTargets(args language.GenerateArgs) []string {
+// This enhanced version searches recursively to support bundles with protos in subdirectories.
+// The bundle's own aggregated rule (<bundle>_all_protos) is excluded: it is an output of this
+// extension, regenerated every pass — discovering it as a source target would wire the aggregate
+// into its own deps (a self-referential proto_library) on any run over an already-generated tree.
+func (pe *protolakeExtension) discoverExistingProtoTargets(args language.GenerateArgs, bundleName string) []string {
 	var targets []string
+	aggregateRuleName := bundleName + "_all_protos"
 
 	// First, check for protos in the current directory (bundle.yaml directory)
-	targets = append(targets, pe.discoverProtoTargetsInDirectory(args.Dir, args.Config.RepoRoot)...)
+	targets = append(targets, pe.discoverProtoTargetsInDirectory(args.Dir, args.Config.RepoRoot, aggregateRuleName)...)
 
 	// Then recursively search subdirectories for additional proto targets
-	subdirTargets := pe.discoverProtoTargetsRecursively(args.Dir, args.Config.RepoRoot)
+	subdirTargets := pe.discoverProtoTargetsRecursively(args.Dir, args.Config.RepoRoot, aggregateRuleName)
 	targets = append(targets, subdirTargets...)
 
 	log.Printf("Discovered %d total proto targets for bundle: %v", len(targets), targets)
 	return targets
 }
 
-// discoverProtoTargetsInDirectory finds proto_library targets in a specific directory
-func (pe *protolakeExtension) discoverProtoTargetsInDirectory(dir string, repoRoot string) []string {
+// discoverProtoTargetsInDirectory finds proto_library targets in a specific directory,
+// skipping any rule named skipRuleName (the bundle's own generated aggregate).
+func (pe *protolakeExtension) discoverProtoTargetsInDirectory(dir string, repoRoot string, skipRuleName string) []string {
 	var targets []string
 
 	// Look for existing BUILD file
@@ -227,6 +232,10 @@ func (pe *protolakeExtension) discoverProtoTargetsInDirectory(dir string, repoRo
 		if len(match) > 1 {
 			name := match[1]
 
+			if name == skipRuleName {
+				continue
+			}
+
 			// Determine the correct target format based on directory relationship
 			pkg, err := filepath.Rel(repoRoot, dir)
 			if err != nil || pkg == "." {
@@ -245,8 +254,9 @@ func (pe *protolakeExtension) discoverProtoTargetsInDirectory(dir string, repoRo
 	return targets
 }
 
-// discoverProtoTargetsRecursively finds proto_library targets in all subdirectories
-func (pe *protolakeExtension) discoverProtoTargetsRecursively(bundleDir string, repoRoot string) []string {
+// discoverProtoTargetsRecursively finds proto_library targets in all subdirectories,
+// skipping any rule named skipRuleName (the bundle's own generated aggregate).
+func (pe *protolakeExtension) discoverProtoTargetsRecursively(bundleDir string, repoRoot string, skipRuleName string) []string {
 	var targets []string
 
 	// Walk through all subdirectories
@@ -268,7 +278,7 @@ func (pe *protolakeExtension) discoverProtoTargetsRecursively(bundleDir string, 
 		// Process BUILD files
 		if info.Name() == buildBazelFile || info.Name() == buildFile {
 			dir := filepath.Dir(path)
-			dirTargets := pe.discoverProtoTargetsInDirectory(dir, repoRoot)
+			dirTargets := pe.discoverProtoTargetsInDirectory(dir, repoRoot, skipRuleName)
 			targets = append(targets, dirTargets...)
 		}
 


### PR DESCRIPTION
Two hygiene items that turned up a real bug, plus review follow-ups.

## What changed

**gofmt sweep** (`chore:` commit) — struct-field alignment in `language/bundle.go` (MergedConfig). Pure formatting; `git diff -w` is empty.

**Fixed-point idempotency pin + discovery fix** (`fix:` commits) — the new `SecondPassIdempotency` case in `integration/integration_test.go` captures every generated `BUILD.bazel` after the existing single-pass assertions, runs gazelle a second time over the same tree, and asserts byte-identical contents per file (and no files appearing/disappearing).

Writing that pin exposed a real bug: on a protolake pass over an already-generated tree, `discoverExistingProtoTargets` re-matched the bundle's own generated `<bundle>_all_protos` aggregate as a source proto target — wiring it into **its own deps** (a self-referential `proto_library`, a bazel dependency-cycle error if built) and into the grpc/es/descriptor rules' `protos`. Pre-fix mechanics, precisely: fresh/cleaned bundles (user, common) corrupted on pass 2; the legacy migration fixture, whose seeded BUILD already carried the aggregate, corrupted on pass 1 and was byte-stable in the corrupted state. The lake service's real two-pass wrapper flow (gazelle proto pass deletes the srcs-less aggregate, then the protolake pass re-adds it) masked the injection; that wrapper flow can still show a benign one-time aggregate relocation on its first run over a pre-steady-state tree — a separate, pre-existing phenomenon.

Discovery now skips the bundle's own aggregate rule name **only when scanning the bundle's own directory** (follow-up commit): a user-defined `proto_library` legitimately named `<bundle>_all_protos` in a *subdirectory* is a real source target and is still discovered — the first cut skipped it everywhere, which would have silently dropped its protos from published artifacts. The recursive scan also no longer rescans the bundle dir's own BUILD file (previously double-scanned). Fixtures pin both sides: a same-named subdir rule asserted wired-in, and the legacy fixture asserting the aggregate never self-references. Post-fix, the protolake pass in isolation is single-pass byte-stable for every bundle shape (fresh, cleaned-in-place, OLD-form migrated), so the idempotency assertion covers the whole tree with no migration carve-out.

## Gates

- `go build ./...` ✓
- `go vet ./...` ✓
- `gofmt -l .` empty ✓
- `go test ./... -count=1` — 19 tests + 17 subtests, 0 failures (integration + language packages both `ok`)

The prebuilt integration gazelle binary (`integration/gazelle_with_protolake_/`) was rebuilt locally from bazel-gazelle v0.47.0 `cmd/gazelle` + this repo's language package; not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)